### PR TITLE
Use custom builder until go-toolset 1.16 is available

### DIFF
--- a/export/Dockerfile
+++ b/export/Dockerfile
@@ -1,12 +1,6 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.15.14 AS crane-builder
+FROM quay.io/konveyor/builder:latest AS crane-builder
 RUN git clone https://github.com/konveyor/crane $APP_ROOT/src/github.com/konveyor/crane
 WORKDIR $APP_ROOT/src/github.com/konveyor/crane
-## Workaround go 1.15 builder. Remove this after go-toolset 1.16 is available
-RUN git checkout e3b31f0fccc5ea827fef75dc24b0321853255e6a
-RUN sed -i 's/\"os\"/"os"\n\t"io\/ioutil"/g' cmd/apply/apply.go
-RUN sed -i 's/os\.ReadFile/ioutil.ReadFile/g' cmd/apply/apply.go
-RUN sed -i 's/go 1.16/go 1.15/g' go.mod
-## End Workaround go 1.15 builder.
 RUN go build -o crane main.go
 
 FROM registry.access.redhat.com/ubi8/go-toolset:1.15.14 AS plugin-builder


### PR DESCRIPTION
One option we can use. I created a pretty basic Fedora builder image at: https://github.com/konveyor/builder and adjusted the Dockerfile here to use it.