### PR TITLE
removing reconciling on not needed resources to better performance

### DIFF
--- a/controllers/export_controller.go
+++ b/controllers/export_controller.go
@@ -32,11 +32,11 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/wait"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1085,13 +1085,7 @@ func (r *ExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&primerv1alpha1.Export{}).
 		Owns(&batchv1.Job{}, builder.OnlyMetadata).
-		Owns(&corev1.ServiceAccount{}, builder.OnlyMetadata).
-		Owns(&corev1.PersistentVolumeClaim{}, builder.OnlyMetadata).
-		Owns(&corev1.Service{}, builder.OnlyMetadata).
 		Owns(&appsv1.Deployment{}, builder.OnlyMetadata).
-		Owns(&corev1.Secret{}, builder.OnlyMetadata).
-		Owns(&routev1.Route{}, builder.OnlyMetadata).
-		Owns(&networkingv1.NetworkPolicy{}, builder.OnlyMetadata).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).


### PR DESCRIPTION
Controller logs:

```
I0329 16:00:22.366274       1 request.go:668] Waited for 1.01177297s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/machineconfiguration.openshift.io/v1?timeout=32s
2022-03-29T16:00:23.754Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2022-03-29T16:00:23.755Z	INFO	setup	starting manager
2022-03-29T16:00:23.755Z	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
2022-03-29T16:00:23.755Z	INFO	controller-runtime.manager.controller.export	Starting EventSource	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "source": "kind source: /, Kind="}
2022-03-29T16:00:23.755Z	INFO	controller-runtime.manager.controller.export	Starting EventSource	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "source": "kind source: batch/v1, Kind=Job"}
2022-03-29T16:00:23.755Z	INFO	controller-runtime.manager.controller.export	Starting EventSource	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "source": "kind source: apps/v1, Kind=Deployment"}
2022-03-29T16:00:23.755Z	INFO	controller-runtime.manager.controller.export	Starting Controller	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export"}
2022-03-29T16:00:23.856Z	INFO	controller-runtime.manager.controller.export	Starting workers	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "worker count": 5}
2022-03-29T16:01:06.192Z	INFO	controller-runtime.manager.controller.export	Creating a new PVC	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "persistentVC.Namespace": "test", "persistentVC.Name": "primer-export-primer"}
2022-03-29T16:01:07.307Z	INFO	controller-runtime.manager.controller.export	Creating a new Job	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "Job.Namespace": "test", "Job.Name": "primer-export-primer"}
2022-03-29T16:01:08.414Z	INFO	controller-runtime.manager.controller.export	Creating a new Service Account	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "serviceAcct.Namespace": "test", "serviceAcct.Name": "primer-export-primer"}
2022-03-29T16:01:09.519Z	INFO	controller-runtime.manager.controller.export	Creating a new oauth Secret	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "proxySecret.Namespace": "test", "proxySecret.Name": "primer-export-primer"}
2022-03-29T16:01:10.625Z	INFO	controller-runtime.manager.controller.export	Creating a new Route	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "appRoute.Namespace": "test", "appRoute.Name": "primer-export-primer"}
2022-03-29T16:01:11.754Z	INFO	controller-runtime.manager.controller.export	Creating a new Cluster Role	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "clusterRole.Namespace": "", "clusterRole.Name": "primer-export-test-primer"}
2022-03-29T16:01:12.880Z	INFO	controller-runtime.manager.controller.export	Creating a new Cluster Role Binding	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "clusterRoleBinding.Namespace": "", "clusterRoleBinding.Name": "primer-export-test-primer"}
2022-03-29T16:01:14.010Z	INFO	controller-runtime.manager.controller.export	Creating a new Network Policy	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "netPol.Namespace": "test", "netPol.Name": "primer-export-primer"}
2022-03-29T16:01:15.115Z	INFO	controller-runtime.manager.controller.export	Creating a new Service	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "service.Namespace": "test", "service.Name": "primer-export-primer"}
2022-03-29T16:01:16.295Z	INFO	controller-runtime.manager.controller.export	Deployment is not ready	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:17.341Z	INFO	controller-runtime.manager.controller.export	Deployment is not ready	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.491Z	INFO	controller-runtime.manager.controller.export	Deployment is not ready	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.559Z	INFO	controller-runtime.manager.controller.export	Cleaning up clusterrole	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.564Z	INFO	controller-runtime.manager.controller.export	cleaning clusterrolebinding	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.567Z	INFO	controller-runtime.manager.controller.export	job cleanup	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.572Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.577Z	INFO	controller-runtime.manager.controller.export	Serving up Export Download	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:51.677Z	INFO	controller-runtime.manager.controller.export	Creating a new Deployment	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test", "deployment.Namespace": "test", "deployment.Name": "primer-export-primer"}
2022-03-29T16:01:52.717Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:52.722Z	INFO	controller-runtime.manager.controller.export	Serving up Export Download	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:52.722Z	INFO	controller-runtime.manager.controller.export	Deployment is not ready	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:52.722Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:52.726Z	INFO	controller-runtime.manager.controller.export	Serving up Export Download	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:52.726Z	INFO	controller-runtime.manager.controller.export	Deployment is not ready	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:55.507Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:55.512Z	INFO	controller-runtime.manager.controller.export	Serving up Export Download	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:55.512Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:55.518Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:55.522Z	INFO	controller-runtime.manager.controller.export	Serving up Export Download	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
2022-03-29T16:01:55.522Z	INFO	controller-runtime.manager.controller.export	Items extracted successfully	{"reconciler group": "primer.gitops.io", "reconciler kind": "Export", "name": "primer", "namespace": "test"}
```