### PR TITLE
setting appropriate security context for pods based on environment

### DIFF
--- a/.github/workflows/validate-primer.yaml
+++ b/.github/workflows/validate-primer.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["main", "release*"]
 
 env:
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   KIND_VERSION: "0.9.0"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/konveyor/gitops-primer"

--- a/bundle/manifests/gitops-primer.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-primer.clusterserviceversion.yaml
@@ -43,6 +43,15 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          resourceNames:
+          - gitops-primer-system
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - ""
           resources:
           - users
           verbs:
@@ -287,8 +296,6 @@ spec:
                   runAsNonRoot: true
               securityContext:
                 runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
               serviceAccountName: gitops-primer-controller-manager
               terminationGracePeriodSeconds: 10
       - name: gitops-primer-mutating-webhook-deployment
@@ -325,8 +332,6 @@ spec:
                   readOnly: true
               securityContext:
                 runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
               volumes:
               - name: export-tls-secret
                 secret:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,8 +23,6 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
         runAsNonRoot: true
       containers:
       - command:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,15 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - gitops-primer-system
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
   resources:
   - users
   verbs:

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -17,8 +17,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
       - name: export-webhook
         # TODO: env var/kustomize this

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cooktheryan/gitops-primer
 
-go 1.16
+go 1.17
 
 require (
 	github.com/evanphx/json-patch v4.11.0+incompatible
@@ -10,9 +10,70 @@ require (
 	github.com/openshift/api v0.0.0-20210625082935-ad54d363d274
 	github.com/operator-framework/operator-lib v0.1.0
 	github.com/sethvargo/go-password v0.2.0
-	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.2
 	sigs.k8s.io/controller-runtime v0.9.2
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.12 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiextensions-apiserver v0.21.2 // indirect
+	k8s.io/component-base v0.21.2 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )


### PR DESCRIPTION
This change is needed because Openshift 4.10 and lesser versions don't allow setting `seccompProfile` through deployment, job, replica set, etc. onto a pod. However, this field needs to be complient with by default `restricted-v2` SCC in environments that are on kube version 1.24+, i.e Openshift 4.11+. So we are setting this field based on kube version of the cluster the operator is running in.